### PR TITLE
Added support for compilation on Darwin

### DIFF
--- a/db/embedded/embedded_darwin.go
+++ b/db/embedded/embedded_darwin.go
@@ -1,0 +1,11 @@
+// +build darwin
+
+package embedded
+
+import (
+	"os/exec"
+)
+
+func addSysProgAttrs(cmd *exec.Cmd) {
+	// darwin users should not use embedded to begin with
+}

--- a/db/embedded/embedded_freebsd.go
+++ b/db/embedded/embedded_freebsd.go
@@ -1,0 +1,11 @@
+// +build freebsd
+
+package embedded
+
+import (
+	"os/exec"
+)
+
+func addSysProgAttrs(cmd *exec.Cmd) {
+	// linux users should not use embedded to begin with
+}

--- a/db/embedded/embedded_freebsd.go
+++ b/db/embedded/embedded_freebsd.go
@@ -7,5 +7,5 @@ import (
 )
 
 func addSysProgAttrs(cmd *exec.Cmd) {
-	// linux users should not use embedded to begin with
+	// freebsd users should not use embedded to begin with
 }

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -177,8 +177,10 @@ func OpenRessource(path string, openWith bool) error {
 	switch runtime.GOOS {
 	case "linux":
 		cmd = exec.Command("xdg-open", path)
-    case "freebsd":
+	case "freebsd":
 		cmd = exec.Command("xdg-open", path)
+        case "darwin":
+                cmd = exec.Command("xdg-open", path)
 	case "windows":
 		if openWith {
 			cmd = exec.Command("openWith", path)

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -177,6 +177,8 @@ func OpenRessource(path string, openWith bool) error {
 	switch runtime.GOOS {
 	case "linux":
 		cmd = exec.Command("xdg-open", path)
+    case "freebsd":
+		cmd = exec.Command("xdg-open", path)
 	case "windows":
 		if openWith {
 			cmd = exec.Command("openWith", path)


### PR DESCRIPTION
I did it the same things also for Darwin OS, like for FreeBSD, now can be compiled also for/on Darwin OS.
Great tool and programming language `go`, we can do binary file for an others platforms (cross compiling).
With:
`go tool dist list` obtain GOOS/GOARCH value and to compile we use:
example for Darwin:
`GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.appVersion=2.5.1.2981"`
or for Windows:
`GOOS=windows GOARCH=amd64 go build -ldflags "-X main.appVersion=2.5.1.2981"`
or for FreeBSD:
`GOOS=freebsd GOARCH=amd64 go build -ldflags "-X main.appVersion=2.5.1.2981"` 
