### PR TITLE
Possible fix for error when there are captions for relations

### DIFF
--- a/config/captionMap/captionMap.go
+++ b/config/captionMap/captionMap.go
@@ -86,6 +86,7 @@ func Get_tx(ctx context.Context, tx pgx.Tx, id pgtype.UUID, target string) (type
 		module_id,
 		pg_function_id,
 		query_choice_id,
+		relation_id,
 		role_id,
 		search_bar_id,
 		tab_id,


### PR DESCRIPTION
Message in log and corresponding popup on Captions Map editor screen:
TRANSACTION {NUMBER} failure (login ID {NUMBER}), can't scan into dest[1] (col: entity_id): uuid: cannot convert to UUID

Empty screen on Captions Map editor screen when there are captions for Application relations