### PR TITLE
Fix error when there are captions for relations

### DIFF
--- a/config/captionMap/captionMap.go
+++ b/config/captionMap/captionMap.go
@@ -86,6 +86,7 @@ func Get_tx(ctx context.Context, tx pgx.Tx, id pgtype.UUID, target string) (type
 		module_id,
 		pg_function_id,
 		query_choice_id,
+		relation_id,
 		role_id,
 		search_bar_id,
 		tab_id,
@@ -244,6 +245,8 @@ func Get_tx(ctx context.Context, tx pgx.Tx, id pgtype.UUID, target string) (type
 			captionMap, exists = caps.PgFunctionIdMap[entityId]
 		case "queryChoice":
 			captionMap, exists = caps.QueryChoiceIdMap[entityId]
+		case "relation":
+			captionMap, exists = caps.RelationIdMap[entityId]
 		case "role":
 			captionMap, exists = caps.RoleIdMap[entityId]
 		case "searchBar":


### PR DESCRIPTION
Fix for case when there are captions for relations and Caption Map does not load entirely
with error message in log
TRANSACTION {NUMBER} failure (login ID {NUMBER}), can't scan into dest[1] (col: entity_id): uuid: cannot convert <nil> to UUID