### PR TITLE
CSV downloads with mime-type

### DIFF
--- a/handler/csv_download/csv_download.go
+++ b/handler/csv_download/csv_download.go
@@ -34,6 +34,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Disposition", "attachment; filename=export.csv")
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
 
 	// read getters from URL
 	token, err := handler.ReadGetterFromUrl(r, "token")


### PR DESCRIPTION
Sets mime-type _text/csv_ for CSV downloads to allow browsers opening the file with the associated software