### PR TITLE
Fix: FormatFloatNumber may truncate large numbers

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -30,7 +30,7 @@ func Substring(s string, start, end int) string {
 
 func FormatFloatNumber(f float64, decCount int, charDec string, charThou string) string {
 	if decCount == -1 {
-		return FormatStringNumber(fmt.Sprintf("%g", f), charDec, charThou)
+		return FormatStringNumber(strconv.FormatFloat(f, 'f', -1, 64), charDec, charThou)
 	}
 	return FormatStringNumber(fmt.Sprintf("%.*f", decCount, f), charDec, charThou)
 }


### PR DESCRIPTION
FormatFloatNumber uses _%g_ when formatting numbers. This defaults to scientific notation for large values and may truncate/round a number when being exported to csv. Furthermore, insertion of the thousands separator makes scientific numbers unparsable for other applications, e.g. _1e.+07_.