### PR TITLE
PDF editor: Position fields in grid layout by entering mm values

### DIFF
--- a/www/comps/builder/builderDocField.js
+++ b/www/comps/builder/builderDocField.js
@@ -195,6 +195,24 @@ export default {
 
 							<template v-if="!isRoot">
 								<tr v-if="isResizeInGrid">
+									<td>{{ capGen.posX }}</td>
+									<td>
+										<div class="row gap centered">
+											<my-input-decimal class="short" v-model="field.posX" :readonly :min="0" :max="sizeXMax" :allowNull="false" :length="5" :lengthFract="2" />
+											<span>mm</span>
+										</div>
+									</td>
+								</tr>
+								<tr v-if="isResizeInGrid">
+									<td>{{ capGen.posY }}</td>
+									<td>
+										<div class="row gap centered">
+											<my-input-decimal class="short" v-model="field.posY" :readonly :min="0" :max="sizeYMax" :allowNull="false" :length="5" :lengthFract="2" />
+											<span>mm</span>
+										</div>
+									</td>
+								</tr>
+								<tr v-if="isResizeInGrid">
 									<td>{{ capGen.sizeX }}</td>
 									<td>
 										<div class="row gap centered">

--- a/www/langs/ar_eg
+++ b/www/langs/ar_eg
@@ -2602,6 +2602,8 @@
 		"placeholders": "Placeholders",
 		"policies": "Policies",
 		"postfix": "Postfix",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Prefix",
 		"preview": "معاينة",
 		"properties": "ملكيات",

--- a/www/langs/de_de
+++ b/www/langs/de_de
@@ -2602,6 +2602,8 @@
 		"placeholders": "Placeholders",
 		"policies": "Richtlinien",
 		"postfix": "Postfix",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Prefix",
 		"preview": "Vorschau",
 		"properties": "Eigenschaften",

--- a/www/langs/en_us
+++ b/www/langs/en_us
@@ -2602,6 +2602,8 @@
 		"placeholders": "Placeholders",
 		"policies": "Policies",
 		"postfix": "Postfix",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Prefix",
 		"preview": "Preview",
 		"properties": "Properties",

--- a/www/langs/es_es
+++ b/www/langs/es_es
@@ -2602,6 +2602,8 @@
 		"placeholders": "Placeholders",
 		"policies": "Policies",
 		"postfix": "Postfix",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Prefix",
 		"preview": "Vista previa",
 		"properties": "Propiedades",

--- a/www/langs/fr_fr
+++ b/www/langs/fr_fr
@@ -2602,6 +2602,8 @@
 		"placeholders": "Placeholders",
 		"policies": "Policies",
 		"postfix": "Postfix",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Prefix",
 		"preview": "Aperçu",
 		"properties": "Propriétés",

--- a/www/langs/hu_hu
+++ b/www/langs/hu_hu
@@ -2602,6 +2602,8 @@
 		"placeholders": "Placeholders",
 		"policies": "Policies",
 		"postfix": "Postfix",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Prefix",
 		"preview": "Előnézet",
 		"properties": "Tulajdonságok",

--- a/www/langs/it_it
+++ b/www/langs/it_it
@@ -2602,6 +2602,8 @@
 		"placeholders": "Placeholders",
 		"policies": "Policies",
 		"postfix": "Postfix",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Prefix",
 		"preview": "Anteprima",
 		"properties": "Properties",

--- a/www/langs/lv_lv
+++ b/www/langs/lv_lv
@@ -2602,6 +2602,8 @@
 		"placeholders": "Placeholders",
 		"policies": "Policies",
 		"postfix": "Postfix",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Prefix",
 		"preview": "Priekšskatījums",
 		"properties": "Īpašības",

--- a/www/langs/pt_pt
+++ b/www/langs/pt_pt
@@ -2602,6 +2602,8 @@
 		"placeholders": "Marcadores de posição",
 		"policies": "Políticas",
 		"postfix": "Sufixo",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Prefixo",
 		"preview": "Pré-visualização",
 		"properties": "Propriedades",

--- a/www/langs/ro_ro
+++ b/www/langs/ro_ro
@@ -2602,6 +2602,8 @@
 		"placeholders": "Placeholders",
 		"policies": "Policies",
 		"postfix": "Postfix",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Prefix",
 		"preview": "Previzualizare",
 		"properties": "Properties",

--- a/www/langs/tr_tr
+++ b/www/langs/tr_tr
@@ -2602,6 +2602,8 @@
 		"placeholders": "Yer tutucular",
 		"policies": "Policies",
 		"postfix": "Sonek",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Önek",
 		"preview": "Önizleme",
 		"properties": "Özellikler",

--- a/www/langs/zh_cn
+++ b/www/langs/zh_cn
@@ -2602,6 +2602,8 @@
 		"placeholders": "Placeholders",
 		"policies": "Policies",
 		"postfix": "Postfix",
+		"posX": "Position ↦",
+		"posY": "Position ↧",
 		"prefix": "Prefix",
 		"preview": "预览",
 		"properties": "属性",


### PR DESCRIPTION
In addition to positioning fields using the mouse, fields within a grid layout can be positioned by entering millimeters values .